### PR TITLE
Upgrade deprecated runtime nodejs6.10

### DIFF
--- a/templates/example.template
+++ b/templates/example.template
@@ -90,7 +90,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       Description: Amazon Connect Example Integration Function
       MemorySize: 128
       Timeout: 30


### PR DESCRIPTION
CloudFormation templates in connect-integration-examples have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs6.10). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.